### PR TITLE
Add accent-color overlay to heading

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -101,10 +101,19 @@ section.events{
                 object-fit: cover;
                 height: 100px;
                 width: 100%;
-                filter: brightness(75%) grayscale(20%);
+                filter: brightness(75%) grayscale(30%);
                 &.light_background {
                     filter: grayscale(20%);
                 }
+            }
+
+            .overlay {
+                background: rgba($accent-color,0.4);
+                position: absolute;
+                top: 0;
+                z-index: 5;
+                height: 100px;
+                width: 100%;
             }
 
             h3 {

--- a/index.md
+++ b/index.md
@@ -16,7 +16,10 @@ description: Find all of HackCU's events in one place.
                         <div class="panel panel-default ">
                             <div class="panel-heading">
                                 <span class="past-text">PAST</span>
-                                {% if event.image-url %}<img class="img-responsive {% unless event.light_background == null %}light_background{% endunless %}" src="{{event.image-url}}">{%endif%}
+                                {% if event.image-url %}
+                                    <div class="overlay"></div>
+                                    <img class="img-responsive {% unless event.light_background == null %}light_background{% endunless %}" src="{{event.image-url}}">
+                                {%endif%}
                                 <h3 {% unless event.light_background == null %} class="light_background"{% endunless %} >{{event.name}}</h3>
                             </div>
                             <div class="panel-body event" data-date="{{ event.date }}">                                


### PR DESCRIPTION
In order to make the website more consistent I added a color overlay to the panel heading. Not sure if this looks better or not.

![screencapture-localhost-4000-1509506589391](https://user-images.githubusercontent.com/6912589/32258708-bc907cb2-be81-11e7-9522-37f56b4d5f2f.png)
