### PR TITLE
Add GitHub internal docs

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at devs@hackcu.org. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing Guidelines
+
+Want to contribute to this repo? Great! We :heart: contributions. Just make sure to follow these guidelines.
+
+## New Feature or a Bug Fix?
+1. Fork the repo (you can ignore this step if you are a part of the HackCU team)
+2. Create a new branch with a descriptive name of the feature or the bug you are fixing.
+3. If you are a part of the HackCU team, push the branch to the remote so that others know that you are working on this branch. Otherwise, create a new issue mentioning that you would like to add a new feature or fix a bug you noticed. This lets us know that someone is already helping us fix the issue!
+4. Make changes and commit them. Your commit messages should be descriptive and imperative. Read [this](http://who-t.blogspot.com/2009/12/on-commit-messages.html) for guidelines.
+5. Test locally and make sure the website functions properly and you didn't break anything.
+6. Create a pull request with a descriptive title. Clearly document any changes you made. You should be able to explain why you made those changes.
+
+## Add/Edit events or footer links
+1. Fork the repo (you can ignore this step if you are a part of the HackCU team)
+2. Create a new branch with a descriptive name of the event or footer link you are adding.
+3. If you are a part of the HackCU team, push the branch to the remote so that others know that you are working on this branch. Otherwise, create a new issue mentioning that you would like to add a new event or footer link. This lets us know that someone is already working on this!
+4. Make changes and commit them. Your commit messages should be descriptive and imperative. Read [this](http://who-t.blogspot.com/2009/12/on-commit-messages.html) for guidelines.
+5. Test locally and make sure the website functions properly and you didn't break anything.
+6. Create a pull request with a descriptive title. You should be able to explain why you are adding/editing this.
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Description
+A few sentences describing the overall goals of the pull request's commits.
+
+## Related Issues
+Link to any issues that are relevant to this PR. This could be an issue this PR fixes.
+
+## Some questions
+- [ ] I read the contributing guidelines
+- [ ] I'm adding a new event/footer link
+- [ ] I'm editing an existing event/footer link
+- [ ] I'm adding a new feature/fixing a bug
+
+If you answered No to question 1, go back and read the [instructions](.github/CONTRIBUTING.md) carefully.
+
+## Additional Notes
+Do you want to add anything else? We :heart: to hear your opinions!


### PR DESCRIPTION
To allow for a better collaboration and contributions in this repo I'm adding our github internal docs, based on the existing ones in hackcu/backend