### PR TITLE
Fix timestamp bug

### DIFF
--- a/calendars/events.ics
+++ b/calendars/events.ics
@@ -13,7 +13,7 @@ END:VTIMEZONE{% assign sorted = site.data.events | sort: 'date','last' %}
 {% for post in sorted %}{% unless post.date == null %}BEGIN:VEVENT
 DTSTART;TZID={{site.timezone}}:{{ post.date | date: "%Y%m%dT%H%M%S" }}
 DTEND;TZID={{site.timezone}}:{{ post.end-date | date: "%Y%m%dT%H%M%S" }}
-DTSTAMP;TZID=America/Denver:{{ post.date | date: "%Y%m%dT%H%M%S" }}
+DTSTAMP;TZID={{site.timezone}}:{{ post.date | date: "%Y%m%dT%H%M%S" }}
 UID:events-{{ post.date | date: "%Y%m%d-%H%M" }}@hackcu.org
 LOCATION:{{ post.location }}
 URL:{{post.url}}


### PR DESCRIPTION
## Description
Fixing a bug in generating the icalendar. Timestamp didn't have a proper timezone

## Some questions
- [X] I read the contributing guidelines
- [ ] I'm adding a new event/footer link
- [ ] I'm editing an existing event/footer link
- [X] I'm adding a new feature/fixing a bug

If you answered No to question 1, go back and read the [instructions](.github/CONTRIBUTING.md) carefully.

## Additional Notes
Do you want to add anything else? We :heart: to hear your opinions!