### PR TITLE
fix github button error

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -51,7 +51,7 @@ fb-community: hackcu
 slack-signup: https://slack.hackcu.org
 
 instagram: hackcu
-github: hackcu
+github-org: hackcu
 
 
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -23,8 +23,8 @@
 				{%unless site.twitter == null %}
 					<a class="btns" target="_blank" href="https://twitter.com/{{site.twitter}}"><i aria-hidden="true" class="fa fa-twitter fa-lg"></i></a>
 				{%endunless%}
-				{%unless site.github == null %}
-					<a class="btns" target="_blank" href="https://github.com/{{site.github}}/"><i aria-hidden="true" class="fa fa-github fa-lg"></i></a>
+				{%unless site.github-org == null %}
+					<a class="btns" target="_blank" href="https://github.com/{{site.github-org}}/"><i aria-hidden="true" class="fa fa-github fa-lg"></i></a>
 				{%endunless%}
 			</div>
 		</div>


### PR DESCRIPTION
## Description
Basically, github seems to populate the github site variables with something. To avoid this I changed the site variable we use to github-org


## Some questions
- [x] I read the contributing guidelines
- [ ] I'm adding a new event/footer link
- [ ] I'm editing an existing event/footer link
- [x] I'm adding a new feature/fixing a bug

If you answered No to question 1, go back and read the [instructions](.github/CONTRIBUTING.md) carefully.

## Additional Notes
Do you want to add anything else? We :heart: to hear your opinions!