### PR TITLE
fix wording groups buttons

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -5,10 +5,10 @@
 				<img src="{{site.logo}}" class="logo">
 				<p class="lead">{{site.author-description}}</p>
 				{% if site.fb-community %}
-					<a class="btn btn-accent btn-block" href="https://facebook.com/groups/{{site.fb-community}}" target="_blank"><i class="fa fa-facebook" aria-hidden="true"></i> Join on Facebook</a>
+					<a class="btn btn-accent btn-block" href="https://facebook.com/groups/{{site.fb-community}}" target="_blank"><i class="fa fa-facebook" aria-hidden="true"></i> Join our Facebook</a>
 				{% endif %}
 				{% if site.slack-signup %}
-					<a class="btn btn-accent btn-block" href="{{site.slack-signup}}" target="_blank"><i class="fa fa-slack" aria-hidden="true"></i> Join on Slack</a>
+					<a class="btn btn-accent btn-block" href="{{site.slack-signup}}" target="_blank"><i class="fa fa-slack" aria-hidden="true"></i> Join our Slack</a>
 				{%endif%}
 			</div>
 			<div class="col-md-5 col-md-offset-2">


### PR DESCRIPTION
## Description
Fix wording buttons to groups. From "Join on Facebook" to "Join our Facebook" (similar to slack)

## Related Issues
Closes #23 

## Some questions
- [x] I read the contributing guidelines
- [ ] I'm adding a new event/footer link
- [ ] I'm editing an existing event/footer link
- [x] I'm adding a new feature/fixing a bug

If you answered No to question 1, go back and read the [instructions](../.github/CONTRIBUTING.md) carefully.

## Additional Notes
Do you want to add anything else? We :heart: to hear your opinions!